### PR TITLE
Remove action dispatching from OperationService

### DIFF
--- a/App.js
+++ b/App.js
@@ -17,7 +17,6 @@ import photonApp from './reducers'
 import PhotonAppContainer from './containers/PhotonAppContainer';
 
 import AccountService from './services/AccountService'
-import OperationService from './services/OperationService'
 
 const persistConfig = {
   key: 'root',
@@ -36,8 +35,7 @@ let store = createStore(
 )
 
 bindStore(store, [
-  AccountService,
-  OperationService
+  AccountService
 ])
 
 let persistor = persistStore(store)

--- a/services/OperationService.js
+++ b/services/OperationService.js
@@ -1,5 +1,3 @@
-import { Connect } from 'redux-ddd';
-
 import {
   addCreateAccountOperation,
   addAccountMergeOperation,
@@ -14,7 +12,6 @@ import {
   addInflationOperation
 } from '../actions'
 
-@Connect()
 class OperationService {
 
   constructor() {

--- a/services/OperationService.js
+++ b/services/OperationService.js
@@ -3,51 +3,51 @@ class OperationService {
 
   constructor() {
     this._parsers = {
-      create_account: (accountId, rawOperation) => {
-        return this.parseCreateAccount(accountId, rawOperation)
+      create_account: (rawOperation) => {
+        return this.parseCreateAccount(rawOperation)
       },
-      payment: (accountId, rawOperation) => {
-        return this.parsePayment(accountId, rawOperation)
+      payment: (rawOperation) => {
+        return this.parsePayment(rawOperation)
       },
-      path_payment: (accountId, rawOperation) => {
-        return this.parsePathPayment(accountId, rawOperation)
+      path_payment: (rawOperation) => {
+        return this.parsePathPayment(rawOperation)
       },
-      manage_offer: (accountId, rawOperation) => {
-        return this.parseManageOffer(accountId, rawOperation)
+      manage_offer: (rawOperation) => {
+        return this.parseManageOffer(rawOperation)
       },
-      create_passive_offer: (accountId, rawOperation) => {
-        return this.parseCreatePassiveOffer(accountId, rawOperation)
+      create_passive_offer: (rawOperation) => {
+        return this.parseCreatePassiveOffer(rawOperation)
       },
-      set_options: (accountId, rawOperation) => {
-        return this.parseSetOptions(accountId, rawOperation)
+      set_options: (rawOperation) => {
+        return this.parseSetOptions(rawOperation)
       },
-      change_trust: (accountId, rawOperation) => {
-        return this.parseChangeTrust(accountId, rawOperation)
+      change_trust: (rawOperation) => {
+        return this.parseChangeTrust(rawOperation)
       },
-      allow_trust: (accountId, rawOperation) => {
-        return this.parseAllowTrust(accountId, rawOperation)
+      allow_trust: (rawOperation) => {
+        return this.parseAllowTrust(rawOperation)
       },
-      account_merge: (accountId, rawOperation) => {
-        return this.parseAccountMerge(accountId, rawOperation)
+      account_merge: (rawOperation) => {
+        return this.parseAccountMerge(rawOperation)
       },
-      inflation: (accountId, rawOperation) => {
-        return this.parseInflation(accountId, rawOperation)
+      inflation: (rawOperation) => {
+        return this.parseInflation(rawOperation)
       },
-      manage_data: (accountId, rawOperation) => {
-        return this.parseManageData(accountId, rawOperation)
+      manage_data: (rawOperation) => {
+        return this.parseManageData(rawOperation)
       }
     }
   }
 
-  parseOperation(accountId, rawOperation) {
+  parseOperation(rawOperation) {
     if (!(rawOperation.type in this._parsers)) {
       log.error('Found an unknown operation type: ' + rawOperation.type)
       return
     }
-    return this._parsers[rawOperation.type](accountId, rawOperation)
+    return this._parsers[rawOperation.type](rawOperation)
   }
 
-  parseCreateAccount(accountId, operation) {
+  parseCreateAccount(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,
@@ -57,7 +57,7 @@ class OperationService {
     }
   }
 
-  parsePayment(accountId, operation) {
+  parsePayment(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,
@@ -70,7 +70,7 @@ class OperationService {
     }
   }
 
-  parsePathPayment(accountId, operation) {
+  parsePathPayment(operation) {
     let basicOp = this._buildBasicOperation(operation)
     let path = operation.path.map(p => {
       return {
@@ -95,7 +95,7 @@ class OperationService {
     }
   }
 
-  parseManageOffer(accountId, operation) {
+  parseManageOffer(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,
@@ -112,7 +112,7 @@ class OperationService {
     }
   }
 
-  parseCreatePassiveOffer(accountId, operation) {
+  parseCreatePassiveOffer(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,
@@ -129,7 +129,7 @@ class OperationService {
     }
   }
 
-  parseSetOptions(accountId, operation) {
+  parseSetOptions(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,
@@ -145,7 +145,7 @@ class OperationService {
     }
   }
 
-  parseChangeTrust(accountId, operation) {
+  parseChangeTrust(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,
@@ -158,7 +158,7 @@ class OperationService {
     }
   }
 
-  parseAllowTrust(accountId, operation) {
+  parseAllowTrust(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,
@@ -171,7 +171,7 @@ class OperationService {
     }
   }
 
-  parseAccountMerge(accountId, operation) {
+  parseAccountMerge(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,
@@ -180,11 +180,11 @@ class OperationService {
     }
   }
 
-  parseInflation(accountId, operation) {
+  parseInflation(operation) {
     return this._buildBasicOperation(operation)
   }
 
-  parseManageData(accountId, operation) {
+  parseManageData(operation) {
     let basicOp = this._buildBasicOperation(operation)
     return {
       ...basicOp,

--- a/services/OperationService.js
+++ b/services/OperationService.js
@@ -15,52 +15,52 @@ import {
 class OperationService {
 
   constructor() {
-    this._processors = {
+    this._parsers = {
       create_account: (accountId, rawOperation) => {
-        this.processCreateAccount(accountId, rawOperation)
+        this.parseCreateAccount(accountId, rawOperation)
       },
       payment: (accountId, rawOperation) => {
-        this.processPayment(accountId, rawOperation)
+        this.parsePayment(accountId, rawOperation)
       },
       path_payment: (accountId, rawOperation) => {
-        this.processPathPayment(accountId, rawOperation)
+        this.parsePathPayment(accountId, rawOperation)
       },
       manage_offer: (accountId, rawOperation) => {
-        this.processManageOffer(accountId, rawOperation)
+        this.parseManageOffer(accountId, rawOperation)
       },
       create_passive_offer: (accountId, rawOperation) => {
-        this.processCreatePassiveOffer(accountId, rawOperation)
+        this.parseCreatePassiveOffer(accountId, rawOperation)
       },
       set_options: (accountId, rawOperation) => {
-        this.processSetOptions(accountId, rawOperation)
+        this.parseSetOptions(accountId, rawOperation)
       },
       change_trust: (accountId, rawOperation) => {
-        this.processChangeTrust(accountId, rawOperation)
+        this.parseChangeTrust(accountId, rawOperation)
       },
       allow_trust: (accountId, rawOperation) => {
-        this.processAllowTrust(accountId, rawOperation)
+        this.parseAllowTrust(accountId, rawOperation)
       },
       account_merge: (accountId, rawOperation) => {
-        this.processAccountMerge(accountId, rawOperation)
+        this.parseAccountMerge(accountId, rawOperation)
       },
       inflation: (accountId, rawOperation) => {
-        this.processInflation(accountId, rawOperation)
+        this.parseInflation(accountId, rawOperation)
       },
       manage_data: (accountId, rawOperation) => {
-        this.processManageData(accountId, rawOperation)
+        this.parseManageData(accountId, rawOperation)
       }
     }
   }
 
-  processOperation(accountId, rawOperation) {
-    if (!(rawOperation.type in this._processors)) {
+  parseOperation(accountId, rawOperation) {
+    if (!(rawOperation.type in this._parsers)) {
       log.error('Found an unknown operation type: ' + rawOperation.type)
       return
     }
-    this._processors[rawOperation.type](accountId, rawOperation)
+    this._parsers[rawOperation.type](accountId, rawOperation)
   }
 
-  processCreateAccount(accountId, operation) {
+  parseCreateAccount(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,
@@ -72,7 +72,7 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processPayment(accountId, operation) {
+  parsePayment(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,
@@ -87,7 +87,7 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processPathPayment(accountId, operation) {
+  parsePathPayment(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let path = operation.path.map(p => {
       return {
@@ -114,7 +114,7 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processManageOffer(accountId, operation) {
+  parseManageOffer(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,
@@ -133,7 +133,7 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processCreatePassiveOffer(accountId, operation) {
+  parseCreatePassiveOffer(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,
@@ -152,7 +152,7 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processSetOptions(accountId, operation) {
+  parseSetOptions(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,
@@ -170,7 +170,7 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processChangeTrust(accountId, operation) {
+  parseChangeTrust(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,
@@ -185,7 +185,7 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processAllowTrust(accountId, operation) {
+  parseAllowTrust(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,
@@ -200,7 +200,7 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processAccountMerge(accountId, operation) {
+  parseAccountMerge(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,
@@ -211,13 +211,13 @@ class OperationService {
     this.dispatch(action)
   }
 
-  processInflation(accountId, operation) {
+  parseInflation(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let action = addInflationOperation(accountId, basicOp)
     this.dispatch(action)
   }
 
-  processManageData(accountId, operation) {
+  parseManageData(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
     let modelOp = {
       ...basicOp,

--- a/services/OperationService.js
+++ b/services/OperationService.js
@@ -1,53 +1,40 @@
-import {
-  addCreateAccountOperation,
-  addAccountMergeOperation,
-  addPaymentOperation,
-  addPathPaymentOperation,
-  addManageOfferOperation,
-  addCreatePassiveOfferOperation,
-  addSetOptionsOperation,
-  addChangeTrustOperation,
-  addAllowTrustOperation,
-  addManageDataOperation,
-  addInflationOperation
-} from '../actions'
 
 class OperationService {
 
   constructor() {
     this._parsers = {
       create_account: (accountId, rawOperation) => {
-        this.parseCreateAccount(accountId, rawOperation)
+        return this.parseCreateAccount(accountId, rawOperation)
       },
       payment: (accountId, rawOperation) => {
-        this.parsePayment(accountId, rawOperation)
+        return this.parsePayment(accountId, rawOperation)
       },
       path_payment: (accountId, rawOperation) => {
-        this.parsePathPayment(accountId, rawOperation)
+        return this.parsePathPayment(accountId, rawOperation)
       },
       manage_offer: (accountId, rawOperation) => {
-        this.parseManageOffer(accountId, rawOperation)
+        return this.parseManageOffer(accountId, rawOperation)
       },
       create_passive_offer: (accountId, rawOperation) => {
-        this.parseCreatePassiveOffer(accountId, rawOperation)
+        return this.parseCreatePassiveOffer(accountId, rawOperation)
       },
       set_options: (accountId, rawOperation) => {
-        this.parseSetOptions(accountId, rawOperation)
+        return this.parseSetOptions(accountId, rawOperation)
       },
       change_trust: (accountId, rawOperation) => {
-        this.parseChangeTrust(accountId, rawOperation)
+        return this.parseChangeTrust(accountId, rawOperation)
       },
       allow_trust: (accountId, rawOperation) => {
-        this.parseAllowTrust(accountId, rawOperation)
+        return this.parseAllowTrust(accountId, rawOperation)
       },
       account_merge: (accountId, rawOperation) => {
-        this.parseAccountMerge(accountId, rawOperation)
+        return this.parseAccountMerge(accountId, rawOperation)
       },
       inflation: (accountId, rawOperation) => {
-        this.parseInflation(accountId, rawOperation)
+        return this.parseInflation(accountId, rawOperation)
       },
       manage_data: (accountId, rawOperation) => {
-        this.parseManageData(accountId, rawOperation)
+        return this.parseManageData(accountId, rawOperation)
       }
     }
   }
@@ -57,24 +44,22 @@ class OperationService {
       log.error('Found an unknown operation type: ' + rawOperation.type)
       return
     }
-    this._parsers[rawOperation.type](accountId, rawOperation)
+    return this._parsers[rawOperation.type](accountId, rawOperation)
   }
 
   parseCreateAccount(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       startingBalance: operation.starting_balance,
       funder: operation.funder,
       account: operation.account
     }
-    let action = addCreateAccountOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parsePayment(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       assetType: operation.asset_type,
       assetCode: operation.asset_code,
@@ -83,8 +68,6 @@ class OperationService {
       to: operation.to,
       amount: operation.amount
     }
-    let action = addPaymentOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parsePathPayment(accountId, operation) {
@@ -96,7 +79,7 @@ class OperationService {
         assetCode: p.asset_code
       }
     })
-    let modelOp = {
+    return {
       ...basicOp,
       from: operation.from,
       to: operation.to,
@@ -110,13 +93,11 @@ class OperationService {
       destinationAmount: operation.amount,
       path: path
     }
-    let action = addPathPaymentOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parseManageOffer(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       offerId: operation.offer_id,
       amount: operation.amount,
@@ -129,13 +110,11 @@ class OperationService {
       sellingAssetIssuer: operation.selling_asset_issuer,
       sellingAssetCode: operation.selling_asset_code
     }
-    let action = addManageOfferOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parseCreatePassiveOffer(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       offerId: operation.offer_id,
       amount: operation.amount,
@@ -148,13 +127,11 @@ class OperationService {
       sellingAssetIssuer: operation.selling_asset_issuer,
       sellingAssetCode: operation.selling_asset_code
     }
-    let action = addCreatePassiveOfferOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parseSetOptions(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       signerKey: operation.signer_key,
       signerWeight: operation.signer_weight,
@@ -166,13 +143,11 @@ class OperationService {
       flagsSet: operation.set_flags_s,
       flagsCleared: operation.clear_flags_s
     }
-    let action = addSetOptionsOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parseChangeTrust(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       assetType: operation.asset_type,
       assetIssuer: operation.asset_issuer,
@@ -181,13 +156,11 @@ class OperationService {
       trustor: operation.trustor,
       limit: operation.limit
     }
-    let action = addChangeTrustOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parseAllowTrust(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       assetType: operation.asset_type,
       assetIssuer: operation.asset_issuer,
@@ -196,36 +169,28 @@ class OperationService {
       trustor: operation.trustor,
       authorize: operation.authorize
     }
-    let action = addAllowTrustOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parseAccountMerge(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       account: operation.account,
       into: operation.into
     }
-    let action = addAccountMergeOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   parseInflation(accountId, operation) {
-    let basicOp = this._buildBasicOperation(operation)
-    let action = addInflationOperation(accountId, basicOp)
-    this.dispatch(action)
+    return this._buildBasicOperation(operation)
   }
 
   parseManageData(accountId, operation) {
     let basicOp = this._buildBasicOperation(operation)
-    let modelOp = {
+    return {
       ...basicOp,
       name: operation.name,
       value: operation.value
     }
-    let action = addManageDataOperation(accountId, modelOp)
-    this.dispatch(action)
   }
 
   _buildBasicOperation(operation) {

--- a/services/OperationService.test.js
+++ b/services/OperationService.test.js
@@ -3,7 +3,6 @@ import OperationService from './OperationService'
 /* eslint-env jest */
 
 it('"create_account" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '31726300645306369',
     paging_token: '31726300645306369',
@@ -28,13 +27,12 @@ it('"create_account" is parsed correctly', () => {
     account: 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
   }
 
-  let op = OperationService.parseCreateAccount(accountId, rawCreateAccount)
+  let op = OperationService.parseCreateAccount(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"payment" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '10157597659144',
     paging_token: '10157597659144',
@@ -65,13 +63,12 @@ it('"payment" is parsed correctly', () => {
     amount: '1000000.0000000'
   }
 
-  let op = OperationService.parsePayment(accountId, rawCreateAccount)
+  let op = OperationService.parsePayment(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"path_payment" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34806814398746625',
     paging_token: '34806814398746625',
@@ -131,13 +128,12 @@ it('"path_payment" is parsed correctly', () => {
     ]
   }
 
-  let op = OperationService.parsePathPayment(accountId, rawCreateAccount)
+  let op = OperationService.parsePathPayment(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"manage_offer" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34824857556357125',
     paging_token: '34824857556357125',
@@ -176,13 +172,12 @@ it('"manage_offer" is parsed correctly', () => {
     sellingAssetCode: 'BTC',
   }
 
-  let op = OperationService.parseManageOffer(accountId, rawCreateAccount)
+  let op = OperationService.parseManageOffer(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"create_passive_offer" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34823581951074305',
     paging_token: '34823581951074305',
@@ -217,13 +212,12 @@ it('"create_passive_offer" is parsed correctly', () => {
     sellingAssetCode: 'OG',
   }
 
-  let op = OperationService.parseCreatePassiveOffer(accountId, rawCreateAccount)
+  let op = OperationService.parseCreatePassiveOffer(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"set_options" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34823135274471425',
     paging_token: '34823135274471425',
@@ -253,13 +247,12 @@ it('"set_options" is parsed correctly', () => {
     homeDomain: undefined,
   }
 
-  let op = OperationService.parseSetOptions(accountId, rawCreateAccount)
+  let op = OperationService.parseSetOptions(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"change_trust" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34823560476233729',
     paging_token: '34823560476233729',
@@ -290,13 +283,12 @@ it('"change_trust" is parsed correctly', () => {
     trustor: 'GBDKJ5MYONYCYKS3HSKTP33DZGWKDDDJ3OY6TOSOZX7AKJ3YVFSEPJMK'
   }
 
-  let op = OperationService.parseChangeTrust(accountId, rawCreateAccount)
+  let op = OperationService.parseChangeTrust(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"allow_trust" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34823564771201025',
     paging_token: '34823564771201025',
@@ -327,13 +319,12 @@ it('"allow_trust" is parsed correctly', () => {
     authorize: true
   }
 
-  let op = OperationService.parseAllowTrust(accountId, rawCreateAccount)
+  let op = OperationService.parseAllowTrust(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"account_merge" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34806625420185601',
     paging_token: '34806625420185601',
@@ -356,13 +347,12 @@ it('"account_merge" is parsed correctly', () => {
     into: 'GBXQXNLHQESJZTSUB5OK5UVG5M66S6F6DKCMUPN77L4MZ4VYVMLFMTQ4'
   }
 
-  let op = OperationService.parseAccountMerge(accountId, rawCreateAccount)
+  let op = OperationService.parseAccountMerge(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"inflation" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34769035866411009',
     paging_token: '34769035866411009',
@@ -381,13 +371,12 @@ it('"inflation" is parsed correctly', () => {
     transactionId: '56fff225470dd77387863bd0bf0190227bdbd23842dc3cfd219264a8c0fec1ac'
   }
 
-  let op = OperationService.parseInflation(accountId, rawCreateAccount)
+  let op = OperationService.parseInflation(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })
 
 it('"manage_data" is parsed correctly', () => {
-  let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
     id: '34820472394747905',
     paging_token: '34820472394747905',
@@ -410,7 +399,7 @@ it('"manage_data" is parsed correctly', () => {
     value: 'MS4w'
   }
 
-  let op = OperationService.parseManageData(accountId, rawCreateAccount)
+  let op = OperationService.parseManageData(rawCreateAccount)
 
   expect(op).toEqual(expectedOperation)
 })

--- a/services/OperationService.test.js
+++ b/services/OperationService.test.js
@@ -5,19 +5,6 @@ import OperationService from './OperationService'
 it('"create_account" is parsed correctly', () => {
   let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
-    _links:
-      {
-        self:
-          { href: 'https://horizon-testnet.stellar.org/operations/31726300645306369' },
-        transaction:
-          { href: 'https://horizon-testnet.stellar.org/transactions/5a54f104b5effc385b4ac575730861ae4eca952dba33bfc4749a520071f2227c' },
-        effects:
-          { href: 'https://horizon-testnet.stellar.org/operations/31726300645306369/effects' },
-        succeeds:
-          { href: 'https://horizon-testnet.stellar.org/effects?order=desc&cursor=31726300645306369' },
-        precedes:
-          { href: 'https://horizon-testnet.stellar.org/effects?order=asc&cursor=31726300645306369' }
-      },
     id: '31726300645306369',
     paging_token: '31726300645306369',
     source_account: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
@@ -41,37 +28,14 @@ it('"create_account" is parsed correctly', () => {
     account: 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
   }
 
-  let expectedAction = {
-    type: 'ADD_CREATE_ACCOUNT_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseCreateAccount(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseCreateAccount(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"payment" is parsed correctly', () => {
   let accountId = 'GAMQWR5ULFVVQWCLU7PL6ZCW7M2IQGJP5FY6LG3HXS4XWPM3F5VDN5IV'
   let rawCreateAccount = {
-    _links:
-      {
-        self:
-          { href: 'https://horizon-testnet.stellar.org/operations/10157597659144' },
-        transaction:
-          { href: 'https://horizon-testnet.stellar.org/transactions/17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a' },
-        effects:
-          { href: 'https://horizon-testnet.stellar.org/operations/10157597659144/effects' },
-        succeeds:
-          { href: 'https://horizon-testnet.stellar.org/effects?order=desc&cursor=10157597659144' },
-        precedes:
-          { href: 'https://horizon-testnet.stellar.org/effects?order=asc&cursor=10157597659144' }
-      },
     id: '10157597659144',
     paging_token: '10157597659144',
     source_account: 'GDNFUWF2EO4OWXYLI4TDEH4DXUCN6PB24R6XQW4VATORK6WGMHGRXJVB',
@@ -101,19 +65,9 @@ it('"payment" is parsed correctly', () => {
     amount: '1000000.0000000'
   }
 
-  let expectedAction = {
-    type: 'ADD_PAYMENT_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parsePayment(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parsePayment(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"path_payment" is parsed correctly', () => {
@@ -177,19 +131,9 @@ it('"path_payment" is parsed correctly', () => {
     ]
   }
 
-  let expectedAction = {
-    type: 'ADD_PATH_PAYMENT_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parsePathPayment(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parsePathPayment(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"manage_offer" is parsed correctly', () => {
@@ -232,19 +176,9 @@ it('"manage_offer" is parsed correctly', () => {
     sellingAssetCode: 'BTC',
   }
 
-  let expectedAction = {
-    type: 'ADD_MANAGE_OFFER_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseManageOffer(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseManageOffer(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"create_passive_offer" is parsed correctly', () => {
@@ -283,19 +217,9 @@ it('"create_passive_offer" is parsed correctly', () => {
     sellingAssetCode: 'OG',
   }
 
-  let expectedAction = {
-    type: 'ADD_CREATE_PASSIVE_OFFER_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseCreatePassiveOffer(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseCreatePassiveOffer(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"set_options" is parsed correctly', () => {
@@ -329,19 +253,9 @@ it('"set_options" is parsed correctly', () => {
     homeDomain: undefined,
   }
 
-  let expectedAction = {
-    type: 'ADD_SET_OPTIONS_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseSetOptions(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseSetOptions(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"change_trust" is parsed correctly', () => {
@@ -376,19 +290,9 @@ it('"change_trust" is parsed correctly', () => {
     trustor: 'GBDKJ5MYONYCYKS3HSKTP33DZGWKDDDJ3OY6TOSOZX7AKJ3YVFSEPJMK'
   }
 
-  let expectedAction = {
-    type: 'ADD_CHANGE_TRUST_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseChangeTrust(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseChangeTrust(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"allow_trust" is parsed correctly', () => {
@@ -423,19 +327,9 @@ it('"allow_trust" is parsed correctly', () => {
     authorize: true
   }
 
-  let expectedAction = {
-    type: 'ADD_ALLOW_TRUST_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseAllowTrust(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseAllowTrust(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"account_merge" is parsed correctly', () => {
@@ -462,19 +356,9 @@ it('"account_merge" is parsed correctly', () => {
     into: 'GBXQXNLHQESJZTSUB5OK5UVG5M66S6F6DKCMUPN77L4MZ4VYVMLFMTQ4'
   }
 
-  let expectedAction = {
-    type: 'ADD_ACCOUNT_MERGE_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseAccountMerge(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseAccountMerge(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"inflation" is parsed correctly', () => {
@@ -497,19 +381,9 @@ it('"inflation" is parsed correctly', () => {
     transactionId: '56fff225470dd77387863bd0bf0190227bdbd23842dc3cfd219264a8c0fec1ac'
   }
 
-  let expectedAction = {
-    type: 'ADD_INFLATION_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseInflation(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseInflation(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })
 
 it('"manage_data" is parsed correctly', () => {
@@ -536,17 +410,7 @@ it('"manage_data" is parsed correctly', () => {
     value: 'MS4w'
   }
 
-  let expectedAction = {
-    type: 'ADD_MANAGE_DATA_OPERATION',
-    accountId: accountId,
-    operation: expectedOperation
-  }
+  let op = OperationService.parseManageData(accountId, rawCreateAccount)
 
-  const mockDispatch = jest.fn()
-  OperationService.dispatch = mockDispatch
-
-  OperationService.parseManageData(accountId, rawCreateAccount)
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
+  expect(op).toEqual(expectedOperation)
 })

--- a/services/OperationService.test.js
+++ b/services/OperationService.test.js
@@ -50,7 +50,7 @@ it('"create_account" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processCreateAccount(accountId, rawCreateAccount)
+  OperationService.parseCreateAccount(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -110,7 +110,7 @@ it('"payment" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processPayment(accountId, rawCreateAccount)
+  OperationService.parsePayment(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -186,7 +186,7 @@ it('"path_payment" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processPathPayment(accountId, rawCreateAccount)
+  OperationService.parsePathPayment(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -241,7 +241,7 @@ it('"manage_offer" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processManageOffer(accountId, rawCreateAccount)
+  OperationService.parseManageOffer(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -292,7 +292,7 @@ it('"create_passive_offer" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processCreatePassiveOffer(accountId, rawCreateAccount)
+  OperationService.parseCreatePassiveOffer(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -338,7 +338,7 @@ it('"set_options" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processSetOptions(accountId, rawCreateAccount)
+  OperationService.parseSetOptions(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -385,7 +385,7 @@ it('"change_trust" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processChangeTrust(accountId, rawCreateAccount)
+  OperationService.parseChangeTrust(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -432,7 +432,7 @@ it('"allow_trust" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processAllowTrust(accountId, rawCreateAccount)
+  OperationService.parseAllowTrust(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -471,7 +471,7 @@ it('"account_merge" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processAccountMerge(accountId, rawCreateAccount)
+  OperationService.parseAccountMerge(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -506,7 +506,7 @@ it('"inflation" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processInflation(accountId, rawCreateAccount)
+  OperationService.parseInflation(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)
@@ -545,7 +545,7 @@ it('"manage_data" is parsed correctly', () => {
   const mockDispatch = jest.fn()
   OperationService.dispatch = mockDispatch
 
-  OperationService.processManageData(accountId, rawCreateAccount)
+  OperationService.parseManageData(accountId, rawCreateAccount)
 
   expect(mockDispatch.mock.calls.length).toBe(1)
   expect(mockDispatch.mock.calls[0][0]).toEqual(expectedAction)


### PR DESCRIPTION
The OperationService should just be a way for retrieving parsed operations (and provide parsing capabilities) from the stellar sdk.

Dispatching actions should not be part of its responsibilities.