### PR TITLE
Add operation's effects to the ADD_OPERATION action

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,13 @@
 module.exports = {
   "parser": "babel-eslint",
   "env": {
-    "browser": true
+    "browser": true,
+    "es6": true
   },
   "extends": ["eslint:recommended", "plugin:react/recommended"],
   "plugins": [
-    "react"
+    "react",
+    "jest"
   ],
   "parserOptions": {
     "ecmaVersion": 2018,

--- a/actions/index.js
+++ b/actions/index.js
@@ -38,10 +38,11 @@ export const addTransaction = (accountId, tx) => {
   }
 }
 
-export const addOperation = (accountId, op) => {
+export const addOperation = (accountId, operation, effects) => {
   return {
     type: 'ADD_OPERATION',
     accountId: accountId,
-    operation: op
+    operation: operation,
+    effects: effects
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-jest": "^21.15.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-react": "^7.7.0",

--- a/services/AccountService.js
+++ b/services/AccountService.js
@@ -5,6 +5,7 @@ import {
   addOperation
 } from '../actions'
 
+import EffectService from './EffectService'
 import OperationService from './OperationService'
 import StellarNetworkService from './StellarNetworkService'
 
@@ -14,6 +15,7 @@ class AccountService {
   constructor() {
     this._stellarNetworkService = StellarNetworkService
     this._operationService = OperationService
+    this._effectService = EffectService
   }
 
   // The onAction listener is called every time an action is
@@ -75,8 +77,15 @@ class AccountService {
   }
 
   _processOperation(accountId, operation) {
-    let addOperationAction = addOperation(accountId, operation)
-    this.dispatch(addOperationAction)
+    this._effectService.getEffectsForOperation(operation.id)
+      .then(effects => {
+        let addOperationAction = addOperation(accountId, operation, effects)
+        this.dispatch(addOperationAction)
+      })
+      .catch(err => {
+        console.debug('Error trying to get the effects for operation: ' + err)
+        this._processOperation(accountId, operation)
+      })
   }
 
   _updateStreams = {}

--- a/services/AccountService.test.js
+++ b/services/AccountService.test.js
@@ -1,0 +1,101 @@
+import AccountService from './AccountService'
+
+/* eslint-env jest */
+
+it('Operation received is properly dispatched after getting its effects', done => {
+  let accountId = 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
+
+  let operationReceived = {
+    id: '31726300645306369',
+    sourceAccount: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
+    type: 'create_account',
+    createdAt: '2018-02-16T07:07:14Z',
+    transactionId: '5a54f104b5effc385b4ac575730861ae4eca952dba33bfc4749a520071f2227c',
+    startingBalance: '10000.0000000',
+    funder: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
+    account: 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
+  }
+
+  let operationEffects = [
+    {
+      id: '0034970078990577665-0000000001',
+      account: 'GCQILV76QLVPFNU3UIW62XEPNAPCSCOM5KVKOUCDQNP7QOFOV4SZ72Q2',
+      type: 'account_created',
+      startingBalance: '10000.0000000'
+    }
+  ]
+
+  let expectedAction = {
+    type: 'ADD_OPERATION',
+    accountId: accountId,
+    operation: operationReceived,
+    effects: operationEffects
+  }
+
+  const dispatchCallback = jest.fn()
+  const effectServiceMock = {
+    getEffectsForOperation: jest.fn()
+  }
+
+  effectServiceMock.getEffectsForOperation.mockReturnValueOnce(Promise.resolve(operationEffects))
+
+  dispatchCallback.mockImplementationOnce(action => {
+    expect(action).toEqual(expectedAction)
+    done()
+  })
+
+  AccountService.dispatch = dispatchCallback
+  AccountService._effectService = effectServiceMock
+
+  AccountService._processOperation(accountId, operationReceived)
+})
+
+it('Keep retrying to get the effects prior dispatching an operation', done => {
+  let accountId = 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
+
+  let operationReceived = {
+    id: '31726300645306369',
+    sourceAccount: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
+    type: 'create_account',
+    createdAt: '2018-02-16T07:07:14Z',
+    transactionId: '5a54f104b5effc385b4ac575730861ae4eca952dba33bfc4749a520071f2227c',
+    startingBalance: '10000.0000000',
+    funder: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
+    account: 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
+  }
+
+  let operationEffects = [
+    {
+      id: '0034970078990577665-0000000001',
+      account: 'GCQILV76QLVPFNU3UIW62XEPNAPCSCOM5KVKOUCDQNP7QOFOV4SZ72Q2',
+      type: 'account_created',
+      startingBalance: '10000.0000000'
+    }
+  ]
+
+  let expectedAction = {
+    type: 'ADD_OPERATION',
+    accountId: accountId,
+    operation: operationReceived,
+    effects: operationEffects
+  }
+
+  const dispatchCallback = jest.fn()
+  const effectServiceMock = {
+    getEffectsForOperation: jest.fn()
+  }
+
+  effectServiceMock.getEffectsForOperation.mockReturnValueOnce(Promise.reject('Error'))
+  effectServiceMock.getEffectsForOperation.mockReturnValueOnce(Promise.reject('Error'))
+  effectServiceMock.getEffectsForOperation.mockReturnValueOnce(Promise.resolve(operationEffects))
+
+  dispatchCallback.mockImplementationOnce(action => {
+    expect(action).toEqual(expectedAction)
+    done()
+  })
+
+  AccountService.dispatch = dispatchCallback
+  AccountService._effectService = effectServiceMock
+
+  AccountService._processOperation(accountId, operationReceived)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2277,6 +2277,10 @@ eslint-plugin-import@^2.9.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
+eslint-plugin-jest@^21.15.0:
+  version "21.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.0.tgz#645a3f560d3e61d99611b215adc80b4f31e6d896"
+
 eslint-plugin-node@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz#bf19642298064379315d7a4b2a75937376fa05e4"


### PR DESCRIPTION
Resolves #14 

Once an operation is received, retrieve the effects and those are obtained dispatch the `ADD_OPERATION` action.

In case retrieving the effects fails, keep retrying.