### PR TITLE
Process the operations sequentially

### DIFF
--- a/services/AccountService.test.js
+++ b/services/AccountService.test.js
@@ -46,6 +46,7 @@ it('Operation received is properly dispatched after getting its effects', done =
 
   AccountService.dispatch = dispatchCallback
   AccountService._effectService = effectServiceMock
+  AccountService._operationsQueueByAccount[accountId] = []
 
   AccountService._processOperation(accountId, operationReceived)
 })
@@ -96,6 +97,7 @@ it('Keep retrying to get the effects prior dispatching an operation', done => {
 
   AccountService.dispatch = dispatchCallback
   AccountService._effectService = effectServiceMock
+  AccountService._operationsQueueByAccount[accountId] = []
 
   AccountService._processOperation(accountId, operationReceived)
 })


### PR DESCRIPTION
Fixes #18 

A queue is used where the operations are appended to it. Only the head of the queue can be processed at a time.

One element that can be improved is to retrieve the effects for the queued operations concurrently. The way it is implemented nothing is done with the operation until it reaches the head of the queue.