### PR TITLE
Do not process operations unless the TX it references has been processed

### DIFF
--- a/services/AccountService.test.js
+++ b/services/AccountService.test.js
@@ -47,6 +47,15 @@ it('Operation received is properly dispatched after getting its effects', done =
   AccountService.dispatch = dispatchCallback
   AccountService._effectService = effectServiceMock
   AccountService._operationsQueueByAccount[accountId] = []
+  AccountService.accounts = {
+    [accountId] : {
+      transactions: {
+        transactionsById: {
+          [operationReceived.transactionId]: {}
+        }
+      }
+    }
+  }
 
   AccountService._processOperation(accountId, operationReceived)
 })
@@ -98,6 +107,127 @@ it('Keep retrying to get the effects prior dispatching an operation', done => {
   AccountService.dispatch = dispatchCallback
   AccountService._effectService = effectServiceMock
   AccountService._operationsQueueByAccount[accountId] = []
+  AccountService.accounts = {
+    [accountId] : {
+      transactions: {
+        transactionsById: {
+          [operationReceived.transactionId]: {}
+        }
+      }
+    }
+  }
 
   AccountService._processOperation(accountId, operationReceived)
+})
+
+it('Operation is not processed if tx is not present', () => {
+  let accountId = 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
+
+  let operationReceived = {
+    id: '31726300645306369',
+    sourceAccount: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
+    type: 'create_account',
+    createdAt: '2018-02-16T07:07:14Z',
+    transactionId: '5a54f104b5effc385b4ac575730861ae4eca952dba33bfc4749a520071f2227c',
+    startingBalance: '10000.0000000',
+    funder: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
+    account: 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
+  }
+
+  const dispatchCallback = jest.fn()
+  const effectServiceMock = {
+    getEffectsForOperation: jest.fn()
+  }
+
+  AccountService.dispatch = dispatchCallback
+  AccountService._effectService = effectServiceMock
+  AccountService._operationsQueueByAccount[accountId] = []
+  AccountService.accounts = {
+    [accountId] : {
+      transactions: {
+        transactionsById: {
+        }
+      }
+    }
+  }
+
+  AccountService._processOperation(accountId, operationReceived)
+  expect(effectServiceMock.getEffectsForOperation.mock.calls.length).toBe(0)
+  expect(dispatchCallback.mock.calls.length).toBe(0)
+})
+
+it('Operation is processed when TX becomes available', done => {
+  let accountId = 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
+
+  let operationReceived = {
+    id: '31726300645306369',
+    sourceAccount: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
+    type: 'create_account',
+    createdAt: '2018-02-16T07:07:14Z',
+    transactionId: '5a54f104b5effc385b4ac575730861ae4eca952dba33bfc4749a520071f2227c',
+    startingBalance: '10000.0000000',
+    funder: 'GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR',
+    account: 'GBZOAKBYRW6O4GUNT2CKSHR4JZ4FE757Z5VQW4YETQRPZP45IQC2UWAQ'
+  }
+
+  let operationEffects = [
+    {
+      id: '0034970078990577665-0000000001',
+      account: 'GCQILV76QLVPFNU3UIW62XEPNAPCSCOM5KVKOUCDQNP7QOFOV4SZ72Q2',
+      type: 'account_created',
+      startingBalance: '10000.0000000'
+    }
+  ]
+
+  let expectedAction = {
+    type: 'ADD_OPERATION',
+    accountId: accountId,
+    operation: operationReceived,
+    effects: operationEffects
+  }
+
+  const dispatchCallback = jest.fn()
+  const effectServiceMock = {
+    getEffectsForOperation: jest.fn()
+  }
+
+  AccountService.dispatch = dispatchCallback
+  AccountService._effectService = effectServiceMock
+  AccountService._operationsQueueByAccount[accountId] = []
+  AccountService.accounts = {
+    [accountId] : {
+      transactions: {
+        transactionsById: {
+        }
+      }
+    }
+  }
+
+  AccountService._processOperation(accountId, operationReceived)
+  expect(effectServiceMock.getEffectsForOperation.mock.calls.length).toBe(0)
+  expect(dispatchCallback.mock.calls.length).toBe(0)
+
+  effectServiceMock.getEffectsForOperation.mockReturnValueOnce(Promise.resolve(operationEffects))
+
+  dispatchCallback.mockImplementationOnce(action => {
+    expect(action).toEqual(expectedAction)
+    done()
+  })
+
+  let prev = {
+    accounts: {
+      ...AccountService.accounts
+    }
+  }
+  AccountService.accounts = {
+    [accountId] : {
+      transactions: {
+        transactionsById: {
+          [operationReceived.transactionId]: {}
+        }
+      }
+    }
+  }
+
+  AccountService.onStateUpdate(prev)
 })


### PR DESCRIPTION
Fixes #4 

If the operation references a TX that has not yet been processed, stop processing it.

Resume processing of the operations as soon as the TX has become available. For this purpose we are now observing the state.