### PR TITLE
Track the account status based on the operations received

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,6 @@ module.exports = {
   "rules": {
     "semi": [2, "never"],
     "no-console": 0,
-    "no-unused-vars": [2, { "varsIgnorePattern": "^_$" }]
+    "no-unused-vars": [2, { "varsIgnorePattern": "^_\d*$", "argsIgnorePattern": "^_\d*$" }]
   },
 }

--- a/reducers/account/state.js
+++ b/reducers/account/state.js
@@ -1,12 +1,44 @@
-
 const initialState = {
   status: 'CLOSED'
 }
 
+const processCreateAccount = (state, action) => {
+  let accountCreatedEffect = action.effects.find(eff => { return eff.type === 'account_created' })
+  if (accountCreatedEffect.account === action.accountId) {
+    return {
+      ...state,
+      status: 'OPEN'
+    }
+  }
+  return state
+}
+
+const processAccountMerge = (state, action) => {
+  let accountRemovedEffect = action.effects.find(eff => { return eff.type === 'account_removed' })
+  if (accountRemovedEffect.account === action.accountId) {
+    return {
+      ...state,
+      status: 'CLOSED'
+    }
+  }
+  return state
+}
+
 const stateReducer = (state = initialState, action) => {
   switch (action.type) {
+  case 'ADD_OPERATION':
+  {
+    switch (action.operation.type) {
+    case 'create_account':
+      return processCreateAccount(state, action)
+    case 'account_merge':
+      return processAccountMerge(state, action)
     default:
       return state
+    }
+  }
+  default:
+    return state
   }
 }
 

--- a/services/AccountService.js
+++ b/services/AccountService.js
@@ -78,7 +78,7 @@ class AccountService {
       .cursor(txCursor)
       .stream({
         onmessage: tx => { this._processTransaction(accountId, tx) },
-        onerror: err => { this._processTransactionError(accountId, err) }
+        onerror: _ => { /* Ignore errors for now */ }
       })
     this._updateStreams[accountId] = {
       operationsStream,

--- a/services/EffectService.js
+++ b/services/EffectService.js
@@ -1,4 +1,4 @@
-import StellarNetworkService from './StellarNetworkService';
+import StellarNetworkService from './StellarNetworkService'
 
 class EffectService {
 
@@ -77,7 +77,7 @@ class EffectService {
 
   parseEffect(rawEffect) {
     if (!(rawEffect.type in this._parserByType)) {
-      log.error('Found an unknown effect type: ' + rawEffect.type)
+      console.log.error('Found an unknown effect type: ' + rawEffect.type)
       return
     }
     return this._parserByType[rawEffect.type](rawEffect)


### PR DESCRIPTION
Resolves #16 

Use the `ADD_OPERATION` action to keep track of the state of the account.

This state can be either 'CLOSED' or 'OPEN' and is kept on the account's `state` state. This functionality is implemented in the account's `state` reducer. 